### PR TITLE
Fixed navigation bug in create new trip

### DIFF
--- a/app/src/main/java/ar/edu/itba/pam/travelapp/newtrip/CreateTripActivity.java
+++ b/app/src/main/java/ar/edu/itba/pam/travelapp/newtrip/CreateTripActivity.java
@@ -204,7 +204,9 @@ public class CreateTripActivity extends AppCompatActivity implements Validator.V
 
     @Override
     public void launchMainActivity() {
-        startActivity(new Intent(getApplicationContext(), MainActivity.class));
+        Intent intent = new Intent(getApplicationContext(), MainActivity.class);
+        intent.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK | Intent.FLAG_ACTIVITY_CLEAR_TASK);
+        startActivity(intent);
     }
 
 }


### PR DESCRIPTION
Now going back from MainActivity won't open CreateNewTrip after creating a new trip. It instead closes the app, as it should.